### PR TITLE
Qt5 VS2008 build fixes.

### DIFF
--- a/recipes/qt5/0001-Don-t-re-typedef-int-_t-if-_STDINT-is-defined.patch
+++ b/recipes/qt5/0001-Don-t-re-typedef-int-_t-if-_STDINT-is-defined.patch
@@ -1,0 +1,84 @@
+From e2ba7d7ecd72c4f3aea706482b96befa30253404 Mon Sep 17 00:00:00 2001
+From: Ray Donnelly <mingw.android@gmail.com>
+Date: Wed, 1 Jun 2016 13:11:07 +0100
+Subject: [PATCH] Don't re-typedef ?int??_t if _STDINT is defined
+
+This is a companion patch for:
+qtbase Change-Id: Ic6b850f85fd620c2ae6232e35a230f9c1f9f8afd
+
+Change-Id: Icfd220bfcddfa644923a720ada8d0b8a95d1c0c1
+---
+ src/3rdparty/assimp/include/assimp/Compiler/pstdint.h | 16 ++++++++++------
+ 1 file changed, 10 insertions(+), 6 deletions(-)
+
+diff --git a/src/3rdparty/assimp/include/assimp/Compiler/pstdint.h b/src/3rdparty/assimp/include/assimp/Compiler/pstdint.h
+index 5bc322f..dc5f9a2 100644
+--- qt3d/src/3rdparty/assimp/include/assimp/Compiler/pstdint.h
++++ qt3d/src/3rdparty/assimp/include/assimp/Compiler/pstdint.h
+@@ -303,7 +303,7 @@
+ #ifndef UINT8_MAX
+ # define UINT8_MAX 0xff
+ #endif
+-#ifndef uint8_t
++#if !defined (uint8_t) && !defined (_STDINT)
+ # if (UCHAR_MAX == UINT8_MAX) || defined (S_SPLINT_S)
+     typedef unsigned char uint8_t;
+ #   define UINT8_C(v) ((uint8_t) v)
+@@ -315,7 +315,7 @@
+ #ifndef INT8_MAX
+ # define INT8_MAX 0x7f
+ #endif
+-#ifndef INT8_MIN
++#if !defined (INT8_MIN) && !defined (_STDINT)
+ # define INT8_MIN INT8_C(0x80)
+ #endif
+ #ifndef int8_t
+@@ -330,7 +330,7 @@
+ #ifndef UINT16_MAX
+ # define UINT16_MAX 0xffff
+ #endif
+-#ifndef uint16_t
++#if !defined (uint16_t) && !defined (_STDINT)
+ #if (UINT_MAX == UINT16_MAX) || defined (S_SPLINT_S)
+   typedef unsigned int uint16_t;
+ # ifndef PRINTF_INT16_MODIFIER
+@@ -354,7 +354,7 @@
+ #ifndef INT16_MIN
+ # define INT16_MIN INT16_C(0x8000)
+ #endif
+-#ifndef int16_t
++#if !defined (int16_t) && !defined (_STDINT)
+ #if (INT_MAX == INT16_MAX) || defined (S_SPLINT_S)
+   typedef signed int int16_t;
+ # define INT16_C(v) ((int16_t) (v))
+@@ -375,7 +375,7 @@
+ #ifndef UINT32_MAX
+ # define UINT32_MAX (0xffffffffUL)
+ #endif
+-#ifndef uint32_t
++#if !defined (uint32_t) && !defined (_STDINT)
+ #if (ULONG_MAX == UINT32_MAX) || defined (S_SPLINT_S)
+   typedef unsigned long uint32_t;
+ # define UINT32_C(v) v ## UL
+@@ -405,7 +405,7 @@
+ #ifndef INT32_MIN
+ # define INT32_MIN INT32_C(0x80000000)
+ #endif
+-#ifndef int32_t
++#if !defined (int32_t) && !defined (_STDINT)
+ #if (LONG_MAX == INT32_MAX) || defined (S_SPLINT_S)
+   typedef signed long int32_t;
+ # define INT32_C(v) v ## L
+@@ -725,5 +725,9 @@ typedef uint_least32_t uint_fast32_t;
+ # define SIG_ATOMIC_MAX ((((sig_atomic_t) 1) << (sizeof (sig_atomic_t)*CHAR_BIT-1)) - 1)
+ #endif
+ 
++#if defined(_MSC_VER) && (_MSC_VER < 1600) && !defined(_STDINT)
++#  define _STDINT
++#endif
++
+ #endif
+ 
+-- 
+2.8.2
+

--- a/recipes/qt5/0001-angle-Split-DirectX-headers-and-libraries-out-from-c.patch
+++ b/recipes/qt5/0001-angle-Split-DirectX-headers-and-libraries-out-from-c.patch
@@ -1,0 +1,122 @@
+From 8b1ce12466d82e1ed865a48a4abe933ce3b137c6 Mon Sep 17 00:00:00 2001
+From: Ray Donnelly <mingw.android@gmail.com>
+Date: Wed, 1 Jun 2016 11:51:15 +0100
+Subject: [PATCH] angle: Split DirectX headers and libraries out from
+ common.pri
+
+... so translator.pro can use it.
+
+translator.pro needs to include DirectX headers, but can't
+include common.pri since that does a lot of inappropriate
+things (like causing shared libraries to be built).
+
+Therefore we split the DirectX headers/libs part out into
+a separate file, common_dx.pri and include that from both
+common.pri and translator.pro
+
+Change-Id: I6b1dd5a4a6e98697732236fbf660e92a8354b6a4
+---
+ src/angle/src/common/common.pri       | 34 +---------------------------------
+ src/angle/src/common/dx_common.pri    | 33 +++++++++++++++++++++++++++++++++
+ src/angle/src/compiler/translator.pro |  1 +
+ 3 files changed, 35 insertions(+), 33 deletions(-)
+ create mode 100644 src/angle/src/common/dx_common.pri
+
+diff --git a/src/angle/src/common/common.pri b/src/angle/src/common/common.pri
+index 50dde63..b00319f 100644
+--- qtbase/src/angle/src/common/common.pri
++++ qtbase/src/angle/src/common/common.pri
+@@ -14,39 +14,7 @@ lib_replace.replace = \$\$\$\$[QT_INSTALL_LIBS]
+ lib_replace.CONFIG = path
+ QMAKE_PRL_INSTALL_REPLACE += lib_replace
+ 
+-# DirectX is included in the Windows 8 Kit, but everything else requires the DX SDK.
+-winrt|if(msvc:!win32-msvc2005:!win32-msvc2008:!win32-msvc2010) {
+-    FXC = fxc.exe
+-} else {
+-    DX_DIR = $$(DXSDK_DIR)
+-    isEmpty(DX_DIR) {
+-        error("Cannot determine DirectX SDK location. Please set DXSDK_DIR environment variable.")
+-    }
+-
+-    DXINC_DIR = $${DX_DIR}Include
+-    contains(QT_ARCH, x86_64) {
+-        DXLIB_DIR = $${DX_DIR}Lib\\x64
+-    } else {
+-        DXLIB_DIR = $${DX_DIR}Lib\\x86
+-    }
+-
+-    equals(QMAKE_TARGET.arch, x86_64) {
+-        FXC = \"$${DX_DIR}Utilities\\bin\\x64\\fxc.exe\"
+-    } else {
+-        FXC = \"$${DX_DIR}Utilities\\bin\\x86\\fxc.exe\"
+-    }
+-
+-    msvc {
+-        # Unfortunately MinGW cannot use the DirectX headers from the DX SDK because d3d11shader.h uses
+-        # buffer annotation macros (eg: __out, __in) which are not defined in the MinGW copy of
+-        # specstrings_strict.h
+-        INCLUDEPATH += $$DXINC_DIR
+-
+-        # Similarly we want the MinGW linker to use the import libraries shipped with the compiler
+-        # instead of those from the SDK which cause a crash on startup.
+-        LIBS_PRIVATE += -L$$DXLIB_DIR
+-    }
+-}
++include(dx_common.pri)
+ 
+ # static builds should still link ANGLE dynamically when dynamic GL is enabled
+ static:contains(QT_CONFIG, dynamicgl) {
+diff --git a/src/angle/src/common/dx_common.pri b/src/angle/src/common/dx_common.pri
+new file mode 100644
+index 0000000..f825cb5
+--- /dev/null
++++ qtbase/src/angle/src/common/dx_common.pri
+@@ -0,0 +1,33 @@
++# DirectX is included in the Windows 8 Kit, but everything else requires the DX SDK.
++winrt|if(msvc:!win32-msvc2005:!win32-msvc2008:!win32-msvc2010) {
++    FXC = fxc.exe
++} else {
++    DX_DIR = $$(DXSDK_DIR)
++    isEmpty(DX_DIR) {
++        error("Cannot determine DirectX SDK location. Please set DXSDK_DIR environment variable.")
++    }
++
++    DXINC_DIR = $${DX_DIR}Include
++    contains(QT_ARCH, x86_64) {
++        DXLIB_DIR = $${DX_DIR}Lib\\x64
++    } else {
++        DXLIB_DIR = $${DX_DIR}Lib\\x86
++    }
++
++    equals(QMAKE_TARGET.arch, x86_64) {
++        FXC = \"$${DX_DIR}Utilities\\bin\\x64\\fxc.exe\"
++    } else {
++        FXC = \"$${DX_DIR}Utilities\\bin\\x86\\fxc.exe\"
++    }
++
++    msvc {
++        # Unfortunately MinGW cannot use the DirectX headers from the DX SDK because d3d11shader.h uses
++        # buffer annotation macros (eg: __out, __in) which are not defined in the MinGW copy of
++        # specstrings_strict.h
++        INCLUDEPATH += $$DXINC_DIR
++
++        # Similarly we want the MinGW linker to use the import libraries shipped with the compiler
++        # instead of those from the SDK which cause a crash on startup.
++        LIBS_PRIVATE += -L$$DXLIB_DIR
++    }
++}
+diff --git a/src/angle/src/compiler/translator.pro b/src/angle/src/compiler/translator.pro
+index b40aa96..430a409 100644
+--- qtbase/src/angle/src/compiler/translator.pro
++++ qtbase/src/angle/src/compiler/translator.pro
+@@ -1,5 +1,6 @@
+ CONFIG += static
+ include(../config.pri)
++include(../common/dx_common.pri)
+ 
+ INCLUDEPATH += \
+     $$ANGLE_DIR/src \
+-- 
+2.8.2
+

--- a/recipes/qt5/0001-shobjidl-Fix-compile-guard-around-SHARDAPPIDINFOLINK.patch
+++ b/recipes/qt5/0001-shobjidl-Fix-compile-guard-around-SHARDAPPIDINFOLINK.patch
@@ -1,0 +1,41 @@
+From c1c59225c94600d1acd0f0f0564005851147d7aa Mon Sep 17 00:00:00 2001
+From: Ray Donnelly <mingw.android@gmail.com>
+Date: Wed, 1 Jun 2016 14:34:42 +0100
+Subject: [PATCH] shobjidl: Fix compile-guard around SHARDAPPIDINFOLINK
+
+Both MSVC and mingw-w64 define NTDDI_VERSION and NTDDI_WIN7 and both
+expose the SHARDAPPIDINFOLINK for >= NTDDI_WIN7, so only define it
+when targeting eariler Windows SDKs.
+
+Change-Id: I5bf297bfc5624d98838e48288c5139acf13fc431
+---
+ src/winextras/winshobjidl_p.h | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
+diff --git a/src/winextras/winshobjidl_p.h b/src/winextras/winshobjidl_p.h
+index 93abea0..fba38a8 100644
+--- qtwinextras/src/winextras/winshobjidl_p.h
++++ qtwinextras/src/winextras/winshobjidl_p.h
+@@ -229,9 +229,7 @@ public:
+ 
+ #endif
+ 
+-#if (defined _MSC_VER && _MSC_VER < 1600) || defined(Q_CC_MINGW)
+-
+-#   if !defined(__MINGW64_VERSION_MAJOR) || !defined(__MINGW64_VERSION_MINOR) || __MINGW64_VERSION_MAJOR * 100 + __MINGW64_VERSION_MINOR < 301
++#if (NTDDI_VERSION < NTDDI_WIN7)
+ 
+ typedef struct SHARDAPPIDINFOLINK
+ {
+@@ -241,8 +239,6 @@ typedef struct SHARDAPPIDINFOLINK
+     PCWSTR pszAppID;        // The id of the application that should be associated with this recent doc.
+ } SHARDAPPIDINFOLINK;
+ 
+-#   endif // !defined(__MINGW64_VERSION_MAJOR) || !defined(__MINGW64_VERSION_MINOR) || __MINGW64_VERSION_MAJOR * 100 + __MINGW64_VERSION_MINOR < 301
+-
+ #endif
+ 
+ #endif // WINSHOBJIDL_P_H
+-- 
+2.8.2
+

--- a/recipes/qt5/0002-angle-Add-Scott-Meyer-s-nullptr-emulation.patch
+++ b/recipes/qt5/0002-angle-Add-Scott-Meyer-s-nullptr-emulation.patch
@@ -1,0 +1,44 @@
+From c1cb1127ba96a3a9df6f0e14b1317a4c58e71131 Mon Sep 17 00:00:00 2001
+From: Ray Donnelly <mingw.android@gmail.com>
+Date: Tue, 31 May 2016 11:04:16 +0100
+Subject: [PATCH 2/4] angle: Add Scott Meyer's nullptr emulation
+
+Change-Id: Idefa6507dc01d5b2cbc0adf94bb3629cc8f58655
+---
+ src/3rdparty/angle/src/common/platform.h | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+
+diff --git a/src/3rdparty/angle/src/common/platform.h b/src/3rdparty/angle/src/common/platform.h
+index 3a2aa91..38174bd 100644
+--- qtbase/src/3rdparty/angle/src/common/platform.h
++++ qtbase/src/3rdparty/angle/src/common/platform.h
+@@ -92,6 +92,26 @@
+ #       define override
+ #   endif
+ 
++#   if defined(_MSC_VER) && (_MSC_VER < 1600)
++    // From Scott Meyer's Effective C++, Second Edition
++    const // It is a const object...
++    class nullptr_t
++    {
++      public:
++        template<class T>
++        inline operator T*() const // convertible to any type of null non-member pointer...
++        { return 0; }
++
++        template<class C, class T>
++        inline operator T C::*() const   // or any type of null member pointer...
++        { return 0; }
++
++      private:
++        void operator&() const;  // Can't take address of nullptr
++
++    } nullptr = {};
++#   endif
++
+ #   undef near
+ #   undef far
+ #endif
+-- 
+2.8.2
+

--- a/recipes/qt5/0003-angle-Add-c-begin-end-iterators.patch
+++ b/recipes/qt5/0003-angle-Add-c-begin-end-iterators.patch
@@ -1,0 +1,39 @@
+From a16dcf923927bb5af17e8faf80e61ac3a6a15e58 Mon Sep 17 00:00:00 2001
+From: Ray Donnelly <mingw.android@gmail.com>
+Date: Tue, 31 May 2016 11:36:34 +0100
+Subject: [PATCH 3/4] angle: Add {c,}{begin,end} iterators
+
+Change-Id: I4a1b12596c73f8dad02362a2098d3501b820a215
+---
+ src/3rdparty/angle/src/common/platform.h | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/src/3rdparty/angle/src/common/platform.h b/src/3rdparty/angle/src/common/platform.h
+index 38174bd..45eff53 100644
+--- qtbase/src/3rdparty/angle/src/common/platform.h
++++ qtbase/src/3rdparty/angle/src/common/platform.h
+@@ -87,6 +87,21 @@
+ #       endif
+ #   endif
+ 
++#   if defined(_MSC_VER) && (_MSC_VER < 1600)
++    template <typename T, size_t N>
++    T* begin(T (&a)[N]) { return a; }
++
++    template <typename T, size_t N>
++    T* end(T (&a)[N]) { return a + N; }
++
++    template <typename T, size_t N>
++    T const* cbegin(T (&a)[N]) { return <const_cast>(a); }
++
++    template <typename T, size_t N>
++    T const* cend(T (&a)[N]) { return <const_cast>(a + N); }
++
++#   endif
++
+ #   if defined(_MSC_VER) && (_MSC_VER <= 1600)
+ #       define final
+ #       define override
+-- 
+2.8.2
+

--- a/recipes/qt5/0004-VS2008-Add-typedefs-for-more-int-_t-and-define-_STDI.patch
+++ b/recipes/qt5/0004-VS2008-Add-typedefs-for-more-int-_t-and-define-_STDI.patch
@@ -1,0 +1,96 @@
+From e645477f7c9a5ca3c30902b1b89290896bbc0847 Mon Sep 17 00:00:00 2001
+From: Ray Donnelly <mingw.android@gmail.com>
+Date: Tue, 31 May 2016 20:23:24 +0100
+Subject: [PATCH 4/4] VS2008: Add typedefs for more ?int??_t and define _STDINT
+
+This allows us to detect later that it's already been done
+as we need to in:
+qtbase/src/3rdparty/harfbuzz-ng/src/hb-common.h
+and:
+qt3d/src/3rdparty/assimp/include/assimp/Compiler/pstdint.h
+
+Also, pstdint.h defines _STDINT so if it got included first
+then we don't define it here. What a mess.
+
+Change-Id: Ic6b850f85fd620c2ae6232e35a230f9c1f9f8afd
+---
+ src/3rdparty/harfbuzz-ng/src/hb-common.h |  2 ++
+ src/gui/opengl/qopenglext.h              | 42 +++++++++++++++++++++++++++++---
+ 2 files changed, 41 insertions(+), 3 deletions(-)
+
+diff --git a/src/3rdparty/harfbuzz-ng/src/hb-common.h b/src/3rdparty/harfbuzz-ng/src/hb-common.h
+index c291dbb..dc7879c 100644
+--- qtbase/src/3rdparty/harfbuzz-ng/src/hb-common.h
++++ qtbase/src/3rdparty/harfbuzz-ng/src/hb-common.h
+@@ -53,6 +53,7 @@
+ #  include <sys/inttypes.h>
+ /* VS 2010 (_MSC_VER 1600) has stdint.h */
+ #elif defined (_MSC_VER) && _MSC_VER < 1600
++#if !defined(_STDINT)
+ typedef __int8 int8_t;
+ typedef unsigned __int8 uint8_t;
+ typedef __int16 int16_t;
+@@ -61,6 +62,7 @@ typedef __int32 int32_t;
+ typedef unsigned __int32 uint32_t;
+ typedef __int64 int64_t;
+ typedef unsigned __int64 uint64_t;
++#endif
+ #else
+ #  include <stdint.h>
+ #endif
+diff --git a/src/gui/opengl/qopenglext.h b/src/gui/opengl/qopenglext.h
+index 72316ca..e3d2f41 100644
+--- qtbase/src/gui/opengl/qopenglext.h
++++ qtbase/src/gui/opengl/qopenglext.h
+@@ -1402,9 +1402,45 @@ typedef unsigned long long int uint64_t;
+ #elif defined(_WIN32) && (defined(__GNUC__) || (defined(_MSC_VER) && _MSC_VER >= 1600))
+ #include <stdint.h>
+ #elif defined(_WIN32)
+-typedef __int32 int32_t;
+-typedef __int64 int64_t;
+-typedef unsigned __int64 uint64_t;
++/* Define _STDINT when we typedef these so we can know later not to
++ * do something daft like defining macros for them. Also define other
++ * things that may reasonably be expected to be defined by stdint.h.
++ */
++#if !defined(_STDINT)
++#define _STDINT
++typedef signed char int8_t;
++typedef short int16_t;
++typedef int int32_t;
++typedef long long int64_t;
++typedef unsigned char uint8_t;
++typedef unsigned short uint16_t;
++typedef unsigned int uint32_t;
++typedef unsigned long long uint64_t;
++#define INT8_C(x) (x)
++#define INT16_C(x) (x)
++#define INT32_C(x) (x)
++#define INT64_C(x) (x ## LL)
++#define UINT8_C(x) (x)
++#define UINT16_C(x) (x)
++#define UINT32_C(x) (x ## U)
++#define UINT64_C(x) (x ## ULL)
++#define INTMAX_C(x) INT64_C(x)
++#define UINTMAX_C(x) UINT64_C(x)
++#define INT8_MIN (-127i8 - 1)
++#define INT16_MIN (-32767i16 - 1)
++#define INT32_MIN (-2147483647i32 - 1)
++#define INT64_MIN (-9223372036854775807i64 - 1)
++#define INT8_MAX 127i8
++#define INT16_MAX 32767i16
++#define INT32_MAX 2147483647i32
++#define INT64_MAX 9223372036854775807i64
++#define UINT8_MAX 0xffui8
++#define UINT16_MAX 0xffffui16
++#define UINT32_MAX 0xffffffffui32
++#define UINT64_MAX 0xffffffffffffffffui64
++#define PRINTF_INT32_MODIFIER ""
++#define PRINTF_INT64_MODIFIER "ll"
++#endif
+ #else
+ /* Fallback if nothing above works */
+ #include <inttypes.h>
+-- 
+2.8.2
+

--- a/recipes/qt5/bld.bat
+++ b/recipes/qt5/bld.bat
@@ -16,15 +16,14 @@ IF "%DXSDK_DIR%" == "" (
     exit 1
 )
 
-curl -LO "http://download.qt.io/community_releases/%SHORT_VERSION%/%PKG_VERSION%/qtwebkit-opensource-src-%PKG_VERSION%.tar.xz"
-if errorlevel 1 exit 1
-7za x -so qtwebkit-opensource-src-%PKG_VERSION%.tar.xz | 7za x -si -aoa -ttar
-if errorlevel 1 exit 1
-MOVE qtwebkit-opensource-src-%PKG_VERSION% qtwebkit
-
 if "%DIRTY%" == "" (
     :: Shorten our build path as much as possible
     :: cd ..
+    curl -LO "http://download.qt.io/community_releases/%SHORT_VERSION%/%PKG_VERSION%/qtwebkit-opensource-src-%PKG_VERSION%.tar.xz"
+    if errorlevel 1 exit 1
+    7za x -so qtwebkit-opensource-src-%PKG_VERSION%.tar.xz | 7za x -si -aoa -ttar
+    if errorlevel 1 exit 1
+    MOVE qtwebkit-opensource-src-%PKG_VERSION% qtwebkit
     mkdir C:\qt5
     :: Copy all files except bld.bat, which needs to stay in place while script runs
     robocopy %SRC_DIR%\ C:\qt5\ *.* /E /move /NFL /NDL /xf bld.bat
@@ -111,7 +110,7 @@ CALL configure ^
 
 :: jom is nmake alternative with multicore support, uses all cores by default
 jom release
-if errorlevel 1 exit 1
+if errorlevel 1 exit /b 1
 jom install
 
 conda remove -y -n python27_qt5_build --all

--- a/recipes/qt5/bld.bat
+++ b/recipes/qt5/bld.bat
@@ -68,6 +68,13 @@ IF %VS_MAJOR% LSS 14 GOTO NOWEBENGINE
     RD /s /q qtwebengine
 :WEBENGINEDONE
 
+IF %VS_MAJOR% LSS 10 GOTO NOANGLE
+    set OPENGLVER=dynamic
+    GOTO ANGLEDONE
+:NOANGLE
+    set OPENGLVER=desktop
+:ANGLEDONE
+
 :: make sure we can find sqlite3:
 set SQLITE3SRCDIR=%CD%\qtbase\src\3rdparty\sqlite
 
@@ -97,7 +104,7 @@ CALL configure ^
      -nomake examples ^
      -nomake tests ^
      -no-warnings-are-errors ^
-     -opengl dynamic ^
+     -opengl %OPENGLVER% ^
      -opensource ^
      -openssl ^
      -platform win32-msvc%VS_YEAR% ^

--- a/recipes/qt5/meta.yaml
+++ b/recipes/qt5/meta.yaml
@@ -25,7 +25,11 @@ source:
     # https://codereview.qt-project.org/#/c/141019/
     # https://codereview.qt-project.org/#/c/141019/3//ALL,unified
     # - vs2015_tst_compiler.patch
+    # qtbase patches:
     - 0001-angle-Split-DirectX-headers-and-libraries-out-from-c.patch
+    - 0004-VS2008-Add-typedefs-for-more-int-_t-and-define-_STDI.patch
+    # qt3d patches:
+    - 0001-Don-t-re-typedef-int-_t-if-_STDINT-is-defined.patch
 
 build:
   detect_binary_files_with_prefix: true   # [unix]

--- a/recipes/qt5/meta.yaml
+++ b/recipes/qt5/meta.yaml
@@ -27,6 +27,8 @@ source:
     # - vs2015_tst_compiler.patch
     # qtbase patches:
     - 0001-angle-Split-DirectX-headers-and-libraries-out-from-c.patch
+    # 0002-angle-Add-Scott-Meyer-s-nullptr-emulation.patch
+    # 0003-angle-Add-c-begin-end-iterators.patch
     - 0004-VS2008-Add-typedefs-for-more-int-_t-and-define-_STDI.patch
     # qt3d patches:
     - 0001-Don-t-re-typedef-int-_t-if-_STDINT-is-defined.patch

--- a/recipes/qt5/meta.yaml
+++ b/recipes/qt5/meta.yaml
@@ -30,6 +30,8 @@ source:
     - 0004-VS2008-Add-typedefs-for-more-int-_t-and-define-_STDI.patch
     # qt3d patches:
     - 0001-Don-t-re-typedef-int-_t-if-_STDINT-is-defined.patch
+    # qtwinextras patches:
+    - 0001-shobjidl-Fix-compile-guard-around-SHARDAPPIDINFOLINK.patch
 
 build:
   detect_binary_files_with_prefix: true   # [unix]

--- a/recipes/qt5/meta.yaml
+++ b/recipes/qt5/meta.yaml
@@ -25,6 +25,7 @@ source:
     # https://codereview.qt-project.org/#/c/141019/
     # https://codereview.qt-project.org/#/c/141019/3//ALL,unified
     # - vs2015_tst_compiler.patch
+    - 0001-angle-Split-DirectX-headers-and-libraries-out-from-c.patch
 
 build:
   detect_binary_files_with_prefix: true   # [unix]


### PR DESCRIPTION
I have had to disable angle since that makes use of C++11 and C++14 quite a bit.

There are two patches to remove this modernity from it, but I've disabled them for now. It's a start at least.

The downside of not using angle (i.e. using desktopgl only instead of dynamically switching between desktopgl and angle) is you depend on the quality (and sometimes existence) of the vendors' drivers.

This can be problematic for VMs in particular where they'll have directx (and hence angle) support but nothing for desktopgl.
