### PR TITLE
Don't use system jpeg and png libraries in OS X to avoid mixing libc++ and libstdc++

### DIFF
--- a/recipes/qt5/build.sh
+++ b/recipes/qt5/build.sh
@@ -89,11 +89,11 @@ if [ `uname` == Darwin ]; then
                 -skip wayland \
                 -skip canvas3d \
                 -skip 3d \
-                -system-libjpeg \
-                -system-libpng \
                 -system-zlib \
                 -qt-pcre \
                 -qt-freetype \
+                -qt-libjpeg \
+                -qt-libpng \
                 -c++11 \
                 -no-framework \
                 -no-dbus \
@@ -102,7 +102,8 @@ if [ `uname` == Darwin ]; then
                 -no-xinput2 \
                 -no-xcb-xlib \
                 -no-libudev \
-                -no-egl
+                -no-egl \
+                -no-openssl
 
     DYLD_FALLBACK_LIBRARY_PATH=$PREFIX/lib make -j $MAKE_JOBS
     make install

--- a/recipes/qt5/meta.yaml
+++ b/recipes/qt5/meta.yaml
@@ -45,14 +45,14 @@ requirements:
     - gst-plugins-base       # [linux]
     - icu           56*
     - jom                    # [win]
-    - jpeg
-    - libpng        1.6*
+    - jpeg                   # [not osx]
+    - libpng        1.6*     # [not osx]
     - libxcb                 # [linux]
     - m2-gperf               # [win]
     - m2-bison               # [win]
     - m2-flex                # [win]
     - m2-git                 # [win]
-    - openssl                # [win or linux]
+    - openssl                # [not osx]
     - perl       >=5.20      # [win]
     - python
     - xz                     # [unix]
@@ -62,12 +62,12 @@ requirements:
     - fontconfig             # [linux]
     - freetype               # [linux]
     - gst-plugins-base       # [linux]
-    - jpeg
+    - jpeg                   # [not osx]
     - icu           56*
     - libgcc                 # [linux]
-    - libpng        1.6*
+    - libpng        1.6*     # [not osx]
     - libxcb                 # [linux]
-    - openssl                # [win or linux]
+    - openssl                # [not osx]
     - zlib
 
 about:


### PR DESCRIPTION
Mike, WebEngine requires Clang to compile on Mac, so we need to avoid (at all costs) mixing these two c++ libraries :-)

I'm following here the Homebrew example too:

https://github.com/Homebrew/homebrew-core/blob/7f5799fd2178001b715827e3a84e021923d357c2/Formula/qt5.rb#L64
